### PR TITLE
Avoid callback url when building a cache key for the result of the AsyncWorker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ tests/testrepo
 dist
 cwl.output.json
 code
+.venv
+.vscode
+data
+example.ipynb

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -119,7 +119,7 @@ def test_service_async_repo(client):
 
     callback_json = json.load(open(callback_fn))
 
-    assert callback_json['status'] == 'done'
+    assert callback_json['action'] == 'done'
 
     r=client.get('/api/v1.0/get/workflow-notebook',
                 query_string=dict(


### PR DESCRIPTION
Dispatcher includes the `time_original_request` parameter into callback URL string and it is different between the first invocation and the one to obtain results after the job is done. If not ignore this parameter, the second request will initiate a new worker and returns 201 to the dispatcher, ending up in an infinite loop. 

Also: 
Callback payload changed to match https://github.com/oda-hub/dispatcher-app/blob/30dd4a13634e9c55500923a81df3746b1ed0a925/cdci_data_analysis/analysis/job_manager.py#L66 

`key_prefix=make_key` is removed in L433 as misleading: it is anyway not used due to `query_string=True`
(I wonder if it's good to also ignore  _async_request_callback for flask-cache keys?)